### PR TITLE
Update build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,5 +33,5 @@ dependencies {
     compile "com.google.firebase:firebase-core:$firebaseCoreVersion"
     compile "com.google.firebase:firebase-messaging:$firebaseMessagingVersion"
     compile 'me.leolin:ShortcutBadger:1.1.17@aar'
-    compile "com.android.support:support-core-utils:28.0.0"
+    compile "com.android.support:support-core-utils:26.1.0"
 }


### PR DESCRIPTION
use a support-core-utils library version that's compatible with our target sdk version
support-core-utils library pulls in a support lib version that corresponds to its version
and we were running into an issue where it was pulling in `appComponentFactory` resource
which doesn't exist for the current target and compile sdk versions